### PR TITLE
[FIX] View blink on iOS 15 when enabling crop

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -891,7 +891,10 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         cropVC.doneButtonTitle = [self.options objectForKey:@"cropperChooseText"];
         cropVC.cancelButtonTitle = [self.options objectForKey:@"cropperCancelText"];
 
-        cropVC.modalPresentationStyle = UIModalPresentationFullScreen;\
+        cropVC.modalPresentationStyle = UIModalPresentationFullScreen;
+		if (@available(iOS 15.0, *)) {
+            cropVC.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+        }
 
         [[self getRootVC] presentViewController:cropVC animated:FALSE completion:nil];
     });


### PR DESCRIPTION
The pr that I used as a base: https://github.com/ivpusic/react-native-image-crop-picker/pull/1739

#### Before

https://user-images.githubusercontent.com/47038980/218867473-2a2aeeba-08e2-4971-83e4-4c82e1485058.MP4



#### After
https://user-images.githubusercontent.com/47038980/218867387-0da68174-cc0a-46c1-9275-619cafa3a39c.mov


