### PR TITLE
feat: persist gif files and force the Heic's mime type to be jpeg

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -846,7 +846,14 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     // create temp file
     NSString *tmpDirFullPath = [self getTmpDirectory];
     NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
-    filePath = [filePath stringByAppendingString:@".jpg"];
+    NSString *mimeType = [self determineMimeTypeFromImageData:data];
+    if ([mimeType isEqualToString:@"image/jpeg"]) {
+        filePath = [filePath stringByAppendingString:@".jpg"];
+    } else if ([mimeType isEqualToString:@"image/gif"]) {
+        filePath = [filePath stringByAppendingString:@".gif"];
+    } else {
+        filePath = [filePath stringByAppendingString:@".jpg"];
+    }
 
     // save cropped file
     BOOL status = [data writeToFile:filePath atomically:YES];

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -516,7 +516,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         case 0x4D:
             return @"image/tiff";
         case 0x00:
-            return @"image/heic";
+			// force Heic mime type to be jpeg too
+            return @"image/jpeg";
     }
     return @"";
 }

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -516,8 +516,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         case 0x4D:
             return @"image/tiff";
         case 0x00:
-            // force the Heic's mime type to be jpeg too
-            return @"image/jpeg";
+            return @"image/heic";
     }
     return @"";
 }
@@ -597,7 +596,8 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
                                     Boolean isKnownMimeType = [mimeType length] > 0;
 
                                     ImageResult *imageResult = [[ImageResult alloc] init];
-                                    if (isLossless && useOriginalWidth && useOriginalHeight && isKnownMimeType && !forceJpg) {
+                                    // force the Heic's mime type to be jpeg too
+                                    if (isLossless && useOriginalWidth && useOriginalHeight && isKnownMimeType && !forceJpg && ![mimeType  isEqualToString:@"image/heic"]) {
                                         // Use original, unmodified image
                                         imageResult.data = imageData;
                                         imageResult.width = @(imgT.size.width);
@@ -848,9 +848,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
     NSString *tmpDirFullPath = [self getTmpDirectory];
     NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
     NSString *mimeType = [self determineMimeTypeFromImageData:data];
-    if ([mimeType isEqualToString:@"image/jpeg"]) {
-        filePath = [filePath stringByAppendingString:@".jpg"];
-    } else if ([mimeType isEqualToString:@"image/gif"]) {
+    if ([mimeType isEqualToString:@"image/gif"]) {
         filePath = [filePath stringByAppendingString:@".gif"];
     } else {
         filePath = [filePath stringByAppendingString:@".jpg"];

--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -516,7 +516,7 @@ RCT_EXPORT_METHOD(openCropper:(NSDictionary *)options
         case 0x4D:
             return @"image/tiff";
         case 0x00:
-			// force Heic mime type to be jpeg too
+            // force the Heic's mime type to be jpeg too
             return @"image/jpeg";
     }
     return @"";


### PR DESCRIPTION
I copied from https://github.com/ministrycentered/react-native-image-crop-picker/pull/1

[TC-398]

[TC-398]: https://rocketchat.atlassian.net/browse/TC-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ